### PR TITLE
Readd older PHP versions support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.4]
+                php: [7.2.5, 7.3, 7.4]
                 laravel: [5.8.*, 6.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.1",
         "illuminate/session": "^5.8|^6.0|^7.0"
     },
     "require-dev": {

--- a/src/Flash.php
+++ b/src/Flash.php
@@ -10,7 +10,8 @@ class Flash
 {
     use Macroable;
 
-    protected Session $session;
+    /** @var \Illuminate\Contracts\Session\Session */
+    protected $session;
 
     public function __construct(Session $session)
     {
@@ -58,7 +59,9 @@ class Flash
     public static function levels(array $methodClasses): void
     {
         foreach ($methodClasses as $method => $classes) {
-            self::macro($method, fn (string $message) => $this->flashMessage(new Message($message, $classes, $method)));
+            self::macro($method, function (string $message) use ($method, $classes) {
+                return $this->flashMessage(new Message($message, $classes, $method));
+            });
         }
     }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -4,11 +4,14 @@ namespace Spatie\Flash;
 
 class Message
 {
-    public string $message;
+    /** @var string */
+    public $message;
 
-    public ?string $class;
+    /** @var string */
+    public $class;
 
-    public ?string $level;
+    /** @var string */
+    public $level;
 
     public function __construct(string $message, $class = null, $level = null)
     {


### PR DESCRIPTION
Coming from https://github.com/spatie/laravel-flash/issues/18..

Is using the 4 typed properties and 1 arrow function really so fundamental for this package to justify dropping support for all pre-PHP 7.4 versions? I'm also using other spatie's packages, which are much much more complex and they do just fine without those two PHP 7.4 features. Actually I haven't come across any other spatie's package that requires anything higher than PHP 7.2.5.

This package also supports Laravel 6 that runs on PHP 7.2.5+, which is a LTS version and still has plenty of its lifetime left, Those of us who cannot simply make our applications require PHP 7.4+ at this moment would really appreciate, if this package kept it's support for pre-7.4 versions.

An option mentioned in above issue is to simply use an older version of this package, but that comes with its cost (for example Laravel 7 and PHP 7.2.5 is not possible combination and also the older version does not include the new "level" property). That forces us to maintain our own fork of this package, if we need any of these things, which is just an additional chore.

I personally came across this package reading this [blog post](https://freek.dev/1291-a-laravel-package-to-flash-messages) and figuring out that I too don't need any of the additional features that other packages provide, but this PHP 7.4 requirement is kinda holding me off.