### PR TITLE
Update Flash.php

### DIFF
--- a/src/Flash.php
+++ b/src/Flash.php
@@ -10,40 +10,40 @@ class Flash
 {
     use Macroable;
 
-    protected Session $session;
+    protected const SESSION_KEY = 'laravel_flash_message';
 
-    public function __construct(Session $session)
-    {
-        $this->session = $session;
-    }
+    public function __construct(
+        protected readonly Session $session
+    ) {}
 
     public function __get(string $name)
     {
-        return $this->getMessage()->$name ?? null;
+        return $this->getMessage()?->$name ?? null;
     }
 
     public function getMessage(): ?Message
     {
-        $flashedMessageProperties = $this->session->get('laravel_flash_message');
+        $data = $this->session->get(self::SESSION_KEY);
 
-        if (! $flashedMessageProperties) {
+        if (!is_array($data)) {
             return null;
         }
 
-        return new Message(
-            $flashedMessageProperties['message'],
-            $flashedMessageProperties['class'],
-            $flashedMessageProperties['level']
-        );
+        ['message' => $message, 'class' => $class, 'level' => $level] = $data + ['message' => null, 'class' => null, 'level' => null];
+
+        if ($message === null || $class === null || $level === null) {
+            return null;
+        }
+
+        return new Message($message, $class, $level);
     }
 
     public function flash(Message $message): void
     {
         if ($message->class && static::hasMacro($message->class)) {
-            $methodName = $message->class;
+            $method = $message->class;
 
-            $this->$methodName($message->message);
-
+            $this->$method($message->message);
             return;
         }
 
@@ -52,13 +52,30 @@ class Flash
 
     public function flashMessage(Message $message): void
     {
-        $this->session->flash('laravel_flash_message', $message->toArray());
+        $this->session->flash(self::SESSION_KEY, $message->toArray());
     }
 
     public static function levels(array $methodClasses): void
     {
-        foreach ($methodClasses as $method => $classes) {
-            self::macro($method, fn (string $message) => $this->flashMessage(new Message($message, $classes, $method)));
+        foreach ($methodClasses as $method => $class) {
+            self::macro($method, function (string $message) use ($class, $method) {
+                $this->flashMessage(new Message($message, $class, $method));
+            });
         }
+    }
+
+    public function forget(): void
+    {
+        $this->session->forget(self::SESSION_KEY);
+    }
+
+    public function hasMessage(): bool
+    {
+        return $this->session->has(self::SESSION_KEY);
+    }
+
+    public function getRaw(): array
+    {
+        return $this->session->get(self::SESSION_KEY, []);
     }
 }


### PR DESCRIPTION
## Commit: Modernize Flash Class with PHP 8+ Features

---

### Changed

- Used `readonly` constructor property for immutability.
- Replaced verbose null checks with the null-safe operator (`?->`).
- Improved internal session handling with proper type-checking and fallbacks.
- Made `SESSION_KEY` a constant to avoid duplication.
- Cleaned up `__get()` to safely access message properties.
- Preserved and improved macro support via `Illuminate\Support\Traits\Macroable`.

---

### New Methods Added

- `hasMessage()`: Check if a flash message exists.
- `forget()`: Clear the flash message manually from session.
- `getRaw()`: Retrieve raw session data (useful for debugging).

