### PR TITLE
Update Message.php

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -10,16 +10,15 @@ class Message
 
     public ?string $level;
 
-    public function __construct(string $message, $class = null, $level = null)
-    {
-        if (is_array($class)) {
-            $class = implode(' ', $class);
-        }
+    protected array $meta = [];
 
+    public function __construct(
+        string $message,
+        string|array|null $class = null,
+        ?string $level = null
+    ) {
         $this->message = $message;
-
-        $this->class = $class;
-
+        $this->class = is_array($class) ? implode(' ', $class) : $class;
         $this->level = $level;
     }
 
@@ -29,6 +28,37 @@ class Message
             'message' => $this->message,
             'class' => $this->class,
             'level' => $this->level,
+            'meta' => $this->meta,
         ];
+    }
+
+    public function withMeta(string $key, mixed $value): static
+    {
+        $this->meta[$key] = $value;
+
+        return $this;
+    }
+
+    public function hasMeta(string $key): bool
+    {
+        return array_key_exists($key, $this->meta);
+    }
+
+    public function getMeta(string $key, mixed $default = null): mixed
+    {
+        return $this->meta[$key] ?? $default;
+    }
+
+    public static function make(
+        string $message,
+        string|array|null $class = null,
+        ?string $level = null
+    ): static {
+        return new static($message, $class, $level);
+    }
+
+    public function __toString(): string
+    {
+        return $this->message;
     }
 }


### PR DESCRIPTION
### What's Changed

- Applied modern type hints: `string|array|null` for flexible input.
- Automatically converts array-based CSS classes to string via `implode()`.
- Introduced optional `meta` array for adding custom key-value data to the message.
- Added `withMeta()` for chaining extra data (e.g. `icon`, `timeout`, etc.).
- Added `hasMeta()` and `getMeta()` for safe meta access.
- Added `__toString()` method to easily cast messages to string (e.g., for logging or view rendering).
- Added a static `make()` constructor for convenience.

